### PR TITLE
[Transaction]: Fixed row update issue for parallel transactions

### DIFF
--- a/src/query/query_engine.rs
+++ b/src/query/query_engine.rs
@@ -562,12 +562,17 @@ impl<E: StorageEngine> NaadanQueryEngine<E> {
             }
             Statement::Commit { chain } => {
                 if session_context.transaction_id() > 0 {
-                    self.transaction_manager
-                        .commit_transaction(session_context.transaction_id())
-                        .unwrap();
+                    let result = self
+                        .transaction_manager
+                        .commit_transaction(session_context.transaction_id());
 
                     session_context.set_transaction_id(0);
                     session_context.set_transaction_type(TransactionType::Implicit);
+
+                    match result {
+                        Ok(()) => {}
+                        Err(err) => return Err(err),
+                    }
                 } else {
                     return Err(NaadanError::TransactionSessionInvalid);
                 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -98,8 +98,13 @@ impl<E: StorageEngine + Send + Sync> NaadanServer<E> {
 
             tokio::spawn(async move {
                 match Self::process_request(server_instance_clone, socket, n).await {
-                    Ok(_) => println!("Request processing done"),
-                    Err(_) => error!("Request processing failed"),
+                    Ok(_) => {
+                        utils::log("Server".to_string(), "Request processing done".to_string())
+                    }
+                    Err(_) => utils::log(
+                        "Server".to_string(),
+                        "Request processing failed".to_string(),
+                    ),
                 }
             });
         }

--- a/src/storage/page.rs
+++ b/src/storage/page.rs
@@ -748,7 +748,11 @@ impl Page {
     pub fn write_to_disk(&self, page_id: PageId) -> Result<(), NaadanError> {
         utils::log(
             "Page".to_string(),
-            format!("Flushing Data: {:?} to disk.", self),
+            format!(
+                "Flushing page {} Data: {:?} to disk.",
+                page_id.get_page_index(),
+                self
+            ),
         );
         let table_data_file = String::from(DB_TABLE_DATA_FILE)
             .replace("{table_id}", page_id.get_table_id().to_string().as_str());


### PR DESCRIPTION
Issue: If parallel transactions are run and one successfully commits, the committed transaction rows were not showing the updated value 

Fix: The issue seemed to be related to version chain, where the version chain had values of both transactions intertwined. However, since the old version chain traversal logic stopped when it came across transaction id of another transaction thus missing out on some updated row values, as a fix now we parse till the end of the version chain.